### PR TITLE
Use proper byte length for content-length

### DIFF
--- a/mailchimp-v3-api.js
+++ b/mailchimp-v3-api.js
@@ -84,7 +84,7 @@ class MailChimpV3 {
         if(typeof data !== 'undefined'){
             options['headers'] = {
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'Content-Length': decodedData.length
+                'Content-Length': Buffer.byteLength(decodedData)
             };
         } else {
             if(this.debug === true){


### PR DESCRIPTION
Some utf-8 string characters are encoded in more bytes 1-4. So the length of a utf-8 encoded JSON string, is not the correct content-length. This was stopping users signing up to my mailing list with Chinese characters in their names!